### PR TITLE
Parse FVM 3 format

### DIFF
--- a/flutterproject/flutterproject_test.go
+++ b/flutterproject/flutterproject_test.go
@@ -91,6 +91,7 @@ func TestProject_FlutterSDKVersionToUse(t *testing.T) {
 			fileOpener := new(mocks.FileManager)
 			fileOpener.On("OpenReaderIfExists", ".tool-versions").Return(strings.NewReader("flutter "+tt.projectSDKFromToolVersions), nil)
 			fileOpener.On("OpenReaderIfExists", ".fvm/fvm_config.json").Return(nil, nil)
+			fileOpener.On("OpenReaderIfExists", ".fvmrc").Return(nil, nil)
 			fileOpener.On("OpenReaderIfExists", "pubspec.lock").Return(nil, nil)
 			fileOpener.On("OpenReaderIfExists", "pubspec.yaml").Return(nil, nil)
 

--- a/flutterproject/internal/sdk/fvm_config.go
+++ b/flutterproject/internal/sdk/fvm_config.go
@@ -10,6 +10,7 @@ import (
 )
 
 const fvmConfigRelPath = ".fvm/fvm_config.json"
+const fvmrcRelPath = ".fvmrc"
 
 type FVMVersionReader struct {
 	fileOpener FileOpener
@@ -22,8 +23,30 @@ func NewFVMVersionReader(fileOpener FileOpener) FVMVersionReader {
 }
 
 func (r FVMVersionReader) ReadSDKVersion(projectRootDir string) (*semver.Version, string, error) {
+	// Try FVM 2.x format first (.fvm/fvm_config.json)
 	fvmConfigPth := filepath.Join(projectRootDir, fvmConfigRelPath)
 	f, err := r.fileOpener.OpenReaderIfExists(fvmConfigPth)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if f != nil {
+		versionStr, channel, err := parseFVMFlutterVersion(f)
+		if err != nil {
+			return nil, "", err
+		}
+		if versionStr != "" {
+			version, err := semver.NewVersion(versionStr)
+			if err != nil {
+				return nil, "", err
+			}
+			return version, channel, nil
+		}
+	}
+
+	// Try FVM 3.x format (.fvmrc)
+	fvmrcPth := filepath.Join(projectRootDir, fvmrcRelPath)
+	f, err = r.fileOpener.OpenReaderIfExists(fvmrcPth)
 	if err != nil {
 		return nil, "", err
 	}
@@ -32,7 +55,7 @@ func (r FVMVersionReader) ReadSDKVersion(projectRootDir string) (*semver.Version
 		return nil, "", nil
 	}
 
-	versionStr, channel, err := parseFVMFlutterVersion(f)
+	versionStr, channel, err := parseFVMRCFlutterVersion(f)
 	if err != nil {
 		return nil, "", err
 	}
@@ -62,6 +85,28 @@ func parseFVMFlutterVersion(fvmConfigReader io.Reader) (string, string, error) {
 	version := config.FlutterSdkVersion
 	channel := ""
 	s := strings.Split(config.FlutterSdkVersion, "@")
+	if len(s) > 1 {
+		version = s[0]
+		channel = strings.Join(s[1:], "@")
+	}
+
+	return version, channel, nil
+}
+
+func parseFVMRCFlutterVersion(fvmrcReader io.Reader) (string, string, error) {
+	type fvmrc struct {
+		Flutter string `json:"flutter"`
+	}
+
+	var config fvmrc
+	d := json.NewDecoder(fvmrcReader)
+	if err := d.Decode(&config); err != nil {
+		return "", "", err
+	}
+
+	version := config.Flutter
+	channel := ""
+	s := strings.Split(config.Flutter, "@")
 	if len(s) > 1 {
 		version = s[0]
 		channel = strings.Join(s[1:], "@")

--- a/flutterproject/internal/sdk/fvm_config_test.go
+++ b/flutterproject/internal/sdk/fvm_config_test.go
@@ -51,3 +51,43 @@ func Test_parseFVMFlutterVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseFVMRCFlutterVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		fvmrcReader    io.Reader
+		wantFlutterSDK string
+		wantChannel    string
+		wantErr        string
+	}{
+		{
+			name:           "Real .fvmrc",
+			fvmrcReader:    strings.NewReader(testassets.FVMRC),
+			wantFlutterSDK: "3.41.7",
+		},
+		{
+			name:           "Real .fvmrc with channel",
+			fvmrcReader:    strings.NewReader(testassets.FVMRCWithChannel),
+			wantFlutterSDK: "3.41.7",
+			wantChannel:    "stable",
+		},
+		{
+			name:        "Empty .fvmrc",
+			fvmrcReader: strings.NewReader(""),
+			wantErr:     "EOF",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFlutterSDK, gotChannel, err := parseFVMRCFlutterVersion(tt.fvmrcReader)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				require.Empty(t, gotFlutterSDK)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantFlutterSDK, gotFlutterSDK)
+				require.Equal(t, tt.wantChannel, gotChannel)
+			}
+		})
+	}
+}

--- a/flutterproject/internal/testassets/fvmrc.go
+++ b/flutterproject/internal/testassets/fvmrc.go
@@ -1,0 +1,9 @@
+package testassets
+
+const FVMRC = `{
+  "flutter": "3.41.7"
+}`
+
+const FVMRCWithChannel = `{
+  "flutter": "3.41.7@stable"
+}`


### PR DESCRIPTION
Adds support for FVM 3.x, which uses `.fvmrc` instead of `.fvm/fvm_config.json`.

The existing FVM 2.x path is checked first; `.fvmrc` is a fallback. Versions with a channel suffix (e.g. `3.41.7@stable`) are handled by stripping the channel part.